### PR TITLE
time card modals now post async

### DIFF
--- a/HabitatForHumanity/Controllers/AdminController.cs
+++ b/HabitatForHumanity/Controllers/AdminController.cs
@@ -118,7 +118,8 @@ namespace HabitatForHumanity.Controllers
                 ViewBag.status = "Failed to update time card, please try again later.";
                 return PartialView("_EditTimeCard", card);
             }
-            return RedirectToAction("Timecards");
+            //return RedirectToAction("Timecards");
+            return PartialView("_EditTimeCardSuccess");
         }
         #endregion
 

--- a/HabitatForHumanity/HabitatForHumanity.csproj
+++ b/HabitatForHumanity/HabitatForHumanity.csproj
@@ -338,6 +338,7 @@
     <Content Include="Views\Admin\ProjectPartialViews\_ProjectCreateSuccess.cshtml" />
     <Content Include="Views\Admin\ProjectPartialViews\_EditProject.cshtml" />
     <Content Include="Views\Admin\OrganizationPartialViews\_OrganizationList.cshtml" />
+    <Content Include="Views\Admin\_EditTimeCardSuccess.cshtml" />
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>

--- a/HabitatForHumanity/Views/Admin/EditVolunteer.cshtml
+++ b/HabitatForHumanity/Views/Admin/EditVolunteer.cshtml
@@ -142,7 +142,7 @@
     $(".editButton").click(function () {
         // console.log('clicked');
         var id = $(this).attr("dataId");
-        console.log(id);
+        //console.log(id);
         inputData = { 'id': id }
 
         $.ajax(
@@ -158,7 +158,24 @@
 
     })
 
-
+    //https://stackoverflow.com/questions/31053460/how-to-make-a-net-mvc-form-inside-a-modal-using-jquery-with-validation
+    //prevents the modal from automatically redirecting when the submit button is clicked
+    //instead we send our post method our form data to do a validation check server side
+    //and return a marked up view to the modal if it's an invalid form
+    $("#editModal").on('submit', function (e) {
+        e.preventDefault();
+        // console.log("prevented from submitting");
+        var form = $("#editTimeCardForm");
+        $.ajax({
+            url: '/Admin/EditTimeCard',
+            type: 'POST',
+            data: form.serialize(),
+            success: function (partialResult) {
+                //  console.log(partialResult);
+                $("#editPartial").html(partialResult);
+            }
+        })
+    });
 
 
     function refresh() {

--- a/HabitatForHumanity/Views/Admin/TimeCards.cshtml
+++ b/HabitatForHumanity/Views/Admin/TimeCards.cshtml
@@ -150,6 +150,25 @@
 
     })
 
+    //https://stackoverflow.com/questions/31053460/how-to-make-a-net-mvc-form-inside-a-modal-using-jquery-with-validation
+    //prevents the modal from automatically redirecting when the submit button is clicked
+    //instead we send our post method our form data to do a validation check server side
+    //and return a marked up view to the modal if it's an invalid form
+    $("#editModal").on('submit', function (e) {
+        e.preventDefault();
+        // console.log("prevented from submitting");
+        var form = $("#editTimeCardForm");
+        $.ajax({
+            url: '/Admin/EditTimeCard',
+            type: 'POST',
+            data: form.serialize(),
+            success: function (partialResult) {
+                //  console.log(partialResult);
+                $("#editPartial").html(partialResult);
+            }
+        })
+    });
+
    
 
 

--- a/HabitatForHumanity/Views/Admin/_EditTimeCard.cshtml
+++ b/HabitatForHumanity/Views/Admin/_EditTimeCard.cshtml
@@ -1,6 +1,6 @@
 ﻿@model HabitatForHumanity.ViewModels.TimeCardVM
 
-@using (Ajax.BeginForm("EditTimeCard", new AjaxOptions { HttpMethod = "POST", OnSuccess = "refresh()" }))
+@using (Html.BeginForm("EditTimeCard", "Admin", FormMethod.Post, new { id = "editTimeCardForm" }))
 {
     @Html.AntiForgeryToken()
 

--- a/HabitatForHumanity/Views/Admin/_EditTimeCardSuccess.cshtml
+++ b/HabitatForHumanity/Views/Admin/_EditTimeCardSuccess.cshtml
@@ -1,0 +1,6 @@
+﻿Successfully edited time card. <button id="modalCloseButton" data-dismiss="modal">Close</button>
+<script type="text/javascript">
+    $("#modalCloseButton").click(function () {
+        location.reload();
+    })
+</script>


### PR DESCRIPTION
Time card editing modals on both the volunteer page aswell as the timecards page now post async. Added a success dialog view as it's the only way around the modal woes. The edit time card function now returns partial views on invalid model state to the modal instead of its own page.